### PR TITLE
feat: Adding ability to have a suffix for event names

### DIFF
--- a/src/EventDriven.EventBus.Abstractions/EventBus.cs
+++ b/src/EventDriven.EventBus.Abstractions/EventBus.cs
@@ -14,9 +14,10 @@ namespace EventDriven.EventBus.Abstractions
         public virtual void Subscribe(
             IIntegrationEventHandler handler,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
         {
-            var topicName = GetTopicName(handler, topic, prefix);
+            var topicName = GetTopicName(handler, topic, prefix, suffix);
             if (Topics.TryGetValue(topicName, out var handlers))
             {
                 handlers.Add(handler);
@@ -31,9 +32,10 @@ namespace EventDriven.EventBus.Abstractions
         public virtual void UnSubscribe(
             IIntegrationEventHandler handler,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
         {
-            var topicName = GetTopicName(handler, topic, prefix);
+            var topicName = GetTopicName(handler, topic, prefix, suffix);
             if (Topics.TryGetValue(topicName, out var handlers))
             {
                 handlers.Remove(handler);
@@ -48,7 +50,8 @@ namespace EventDriven.EventBus.Abstractions
         public abstract Task PublishAsync<TIntegrationEvent>(
             TIntegrationEvent @event,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
             where TIntegrationEvent : IntegrationEvent;
 
         /// <summary>
@@ -57,11 +60,13 @@ namespace EventDriven.EventBus.Abstractions
         /// <param name="handler">Subscription event handler.</param>
         /// <param name="topic">Subscription topic.</param>
         /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
         /// <returns>Fully qualified topic name.</returns>
         protected string GetTopicName(
             IIntegrationEventHandler handler,
             string? topic,
-            string? prefix) => FormatTopicName(handler.Topic, topic, prefix);
+            string? prefix,
+            string? suffix) => FormatTopicName(handler.Topic, topic, prefix, suffix);
 
         /// <summary>
         /// Get topic name from event handler.
@@ -69,19 +74,23 @@ namespace EventDriven.EventBus.Abstractions
         /// <param name="eventType">Integration event type.</param>
         /// <param name="topic">Subscription topic.</param>
         /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
         /// <returns>Fully qualified topic name.</returns>
         protected string GetTopicName(
             Type eventType,
             string? topic,
-            string? prefix) => FormatTopicName(eventType.Name, topic, prefix);
+            string? prefix,
+            string? suffix) => FormatTopicName(eventType.Name, topic, prefix, suffix);
 
         private string FormatTopicName(
             string implicitTopic,
             string? explicitTopic,
-            string? prefix)
+            string? prefix,
+            string? suffix)
         {
             var topicName = string.IsNullOrWhiteSpace(explicitTopic) ? implicitTopic : explicitTopic;
             topicName = string.IsNullOrWhiteSpace(prefix) ? topicName : $"{prefix}.{topicName}";
+            topicName = string.IsNullOrWhiteSpace(suffix) ? topicName : $"{topicName}.{suffix}";
             return topicName;
         }
     }

--- a/src/EventDriven.EventBus.Abstractions/IEventBus.cs
+++ b/src/EventDriven.EventBus.Abstractions/IEventBus.cs
@@ -19,10 +19,12 @@ namespace EventDriven.EventBus.Abstractions
         /// <param name="handler">Subscription event handler.</param>
         /// <param name="topic">Subscription topic.</param>
         /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
         void Subscribe(
             IIntegrationEventHandler handler,
             string? topic = null,
-            string? prefix = null);
+            string? prefix = null,
+            string? suffix = null);
 
         /// <summary>
         /// Unregister a subscription with an event handler.
@@ -30,10 +32,12 @@ namespace EventDriven.EventBus.Abstractions
         /// <param name="handler">Subscription event handler.</param>
         /// <param name="topic">Subscription topic.</param>
         /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
         void UnSubscribe(
             IIntegrationEventHandler handler,
             string? topic = null,
-            string? prefix = null);
+            string? prefix = null,
+            string? suffix = null);
 
         /// <summary>
         /// Publish an event asynchronously.
@@ -42,11 +46,13 @@ namespace EventDriven.EventBus.Abstractions
         /// <param name="event">Integration event.</param>
         /// <param name="topic">Publication topic.</param>
         /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
         /// <returns>Task that will complete when the operation has completed.</returns>
         Task PublishAsync<TIntegrationEvent>(
             TIntegrationEvent @event,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
             where TIntegrationEvent : IntegrationEvent;
     }
 }

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
@@ -9,11 +9,13 @@ namespace EventDriven.EventBus.Abstractions.Tests
     public class EventBusTests
     {
         [Theory]
-        [InlineData(TopicType.Implicit, null)]
-        [InlineData(TopicType.Implicit, "v1")]
-        [InlineData(TopicType.Explicit, null)]
-        [InlineData(TopicType.Explicit, "v1")]
-        public async Task EventBus_Should_Invoke_Event_Handlers(TopicType topicType, string prefix)
+        [InlineData(TopicType.Implicit, null, null)]
+        [InlineData(TopicType.Implicit, "v1", null)]
+        [InlineData(TopicType.Explicit, null, null)]
+        [InlineData(TopicType.Explicit, "v1", null)]
+        [InlineData(TopicType.Explicit, null, "suffix")]
+        [InlineData(TopicType.Explicit, "v1", "suffix")]
+        public async Task EventBus_Should_Invoke_Event_Handlers(TopicType topicType, string prefix, string suffix)
         {
             // Topic name
             var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
@@ -25,17 +27,17 @@ namespace EventDriven.EventBus.Abstractions.Tests
 
             // Create message broker
             var messageBroker = new FakeMessageBroker();
-            messageBroker.Subscribe(fakeHandler1, topicName, prefix);
-            messageBroker.Subscribe(fakeHandler2, topicName, prefix);
+            messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
+            messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
             // Create event bus
             var eventBus = new FakeEventBus(messageBroker);
-            eventBus.Subscribe(fakeHandler1, topicName, prefix);
-            eventBus.Subscribe(fakeHandler2, topicName, prefix);
+            eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
+            eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
             // Publish to service bus
             var @event = new FakeIntegrationEvent("B");
-            await eventBus.PublishAsync(@event, topicName, prefix);
+            await eventBus.PublishAsync(@event, topicName, prefix, suffix);
 
             // Assert
             Assert.Equal(@event.CreationDate, state.Date);

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
@@ -45,11 +45,13 @@ namespace EventDriven.EventBus.Abstractions.Tests
         }
         
         [Theory]
-        [InlineData(TopicType.Implicit, null)]
-        [InlineData(TopicType.Implicit, "v1")]
-        [InlineData(TopicType.Explicit, null)]
-        [InlineData(TopicType.Explicit, "v1")]
-        public void EventBus_Should_Remove_Event_Handlers(TopicType topicType, string prefix)
+        [InlineData(TopicType.Implicit, null, null)]
+        [InlineData(TopicType.Implicit, "v1", null)]
+        [InlineData(TopicType.Explicit, null, null)]
+        [InlineData(TopicType.Explicit, "v1", null)]
+        [InlineData(TopicType.Explicit, null, "suffix")]
+        [InlineData(TopicType.Explicit, "v1", "suffix")]
+        public void EventBus_Should_Remove_Event_Handlers(TopicType topicType, string prefix, string suffix)
         {
             // Topic name
             var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
@@ -61,23 +63,23 @@ namespace EventDriven.EventBus.Abstractions.Tests
 
             // Create message broker
             var messageBroker = new FakeMessageBroker();
-            messageBroker.Subscribe(fakeHandler1, topicName, prefix);
-            messageBroker.Subscribe(fakeHandler2, topicName, prefix);
+            messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
+            messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
             // Create event bus
             var eventBus = new FakeEventBus(messageBroker);
-            eventBus.Subscribe(fakeHandler1, topicName, prefix);
-            eventBus.Subscribe(fakeHandler2, topicName, prefix);
+            eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
+            eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
             // Remove handler
-            eventBus.UnSubscribe(fakeHandler1, topicName, prefix);
+            eventBus.UnSubscribe(fakeHandler1, topicName, prefix, suffix);
 
             // Assert
             Assert.Single(eventBus.Topics);
             Assert.Single(eventBus.Topics.First().Value);
             
             // Remove handler
-            eventBus.UnSubscribe(fakeHandler2, topicName, prefix);
+            eventBus.UnSubscribe(fakeHandler2, topicName, prefix, suffix);
 
             // Assert
             Assert.Empty(eventBus.Topics);

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeEventBus.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeEventBus.cs
@@ -14,9 +14,10 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
         public override async Task PublishAsync<TIntegrationEvent>(
             TIntegrationEvent @event,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
         {
-            var topicName = GetTopicName(@event.GetType(), topic, prefix);
+            var topicName = GetTopicName(@event.GetType(), topic, prefix, suffix);
             await MessageBroker.PublishEventAsync(@event, topicName);
         }
     }

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeMessageBroker.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeMessageBroker.cs
@@ -10,10 +10,12 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
         public virtual void Subscribe(
             IIntegrationEventHandler handler,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
         {
             var topicName = string.IsNullOrWhiteSpace(topic) ? handler.Topic : topic;
             topicName = string.IsNullOrWhiteSpace(prefix) ? topicName : $"{prefix}.{topicName}";
+            topicName = string.IsNullOrWhiteSpace(suffix) ? topicName : $"{topicName}.{suffix}";
             if (Topics.TryGetValue(topicName, out var handlers))
             {
                 handlers.Add(handler);

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeRepeatingEventBus.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeRepeatingEventBus.cs
@@ -20,9 +20,10 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
         public override async Task PublishAsync<TIntegrationEvent>(
             TIntegrationEvent @event,
             string? topic = null,
-            string? prefix = null)
+            string? prefix = null,
+            string? suffix = null)
         {
-            var topicName = GetTopicName(@event.GetType(), topic, prefix);
+            var topicName = GetTopicName(@event.GetType(), topic, prefix, suffix);
             for (int i = 0; i < _iterations; i++)
             {
                 await MessageBroker.PublishEventAsync(@event, topicName);


### PR DESCRIPTION
As with the prefix parameter on all publish and subscribe methods, I have added 'suffix' to the function signatures.
This gives a nice extension ability to users not having to format their event names with prefix and suffix by hand.

Closes #3 

