### PR TITLE
Add Topic Info Attribute

### DIFF
--- a/src/EventDriven.EventBus.Abstractions/EventBus.cs
+++ b/src/EventDriven.EventBus.Abstractions/EventBus.cs
@@ -1,97 +1,113 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
-namespace EventDriven.EventBus.Abstractions
+namespace EventDriven.EventBus.Abstractions;
+
+///<inheritdoc/>
+public abstract class EventBus : IEventBus
 {
     ///<inheritdoc/>
-    public abstract class EventBus : IEventBus
+    public Dictionary<string, List<IIntegrationEventHandler>> Topics { get; } = new();
+
+    ///<inheritdoc/>
+    public virtual void Subscribe(
+        IIntegrationEventHandler handler,
+        string? topic = null,
+        string? prefix = null,
+        string? suffix = null)
     {
-        ///<inheritdoc/>
-        public Dictionary<string, List<IIntegrationEventHandler>> Topics { get; } = new();
+        var topicName = GetTopicName(handler, topic, prefix, suffix);
+        if (Topics.TryGetValue(topicName, out var handlers))
+            handlers.Add(handler);
+        else
+            Topics.Add(topicName, new List<IIntegrationEventHandler> { handler });
+    }
 
-        ///<inheritdoc/>
-        public virtual void Subscribe(
-            IIntegrationEventHandler handler,
-            string? topic = null,
-            string? prefix = null,
-            string? suffix = null)
+    ///<inheritdoc/>
+    public virtual void UnSubscribe(
+        IIntegrationEventHandler handler,
+        string? topic = null,
+        string? prefix = null,
+        string? suffix = null)
+    {
+        var topicName = GetTopicName(handler, topic, prefix, suffix);
+        if (!Topics.TryGetValue(topicName, out var handlers)) return;
+        handlers.Remove(handler);
+        if (handlers.Count == 0)
         {
-            var topicName = GetTopicName(handler, topic, prefix, suffix);
-            if (Topics.TryGetValue(topicName, out var handlers))
-            {
-                handlers.Add(handler);
-            }
-            else
-            {
-                Topics.Add(topicName, new List<IIntegrationEventHandler> { handler });
-            }
+            Topics.Remove(topicName);
         }
-        
-        ///<inheritdoc/>
-        public virtual void UnSubscribe(
-            IIntegrationEventHandler handler,
-            string? topic = null,
-            string? prefix = null,
-            string? suffix = null)
-        {
-            var topicName = GetTopicName(handler, topic, prefix, suffix);
-            if (Topics.TryGetValue(topicName, out var handlers))
-            {
-                handlers.Remove(handler);
-                if (handlers.Count == 0)
-                {
-                    Topics.Remove(topicName);
-                }
-            }
-        }
+    }
 
-        ///<inheritdoc/>
-        public abstract Task PublishAsync<TIntegrationEvent>(
-            TIntegrationEvent @event,
-            string? topic = null,
-            string? prefix = null,
-            string? suffix = null)
-            where TIntegrationEvent : IntegrationEvent;
+    ///<inheritdoc/>
+    public abstract Task PublishAsync<TIntegrationEvent>(
+        TIntegrationEvent @event,
+        string? topic = null,
+        string? prefix = null,
+        string? suffix = null)
+        where TIntegrationEvent : IntegrationEvent;
 
-        /// <summary>
-        /// Get topic name from event handler.
-        /// </summary>
-        /// <param name="handler">Subscription event handler.</param>
-        /// <param name="topic">Subscription topic.</param>
-        /// <param name="prefix">Dot delimited prefix, which can include version.</param>
-        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
-        /// <returns>Fully qualified topic name.</returns>
-        protected string GetTopicName(
-            IIntegrationEventHandler handler,
-            string? topic,
-            string? prefix,
-            string? suffix) => FormatTopicName(handler.Topic, topic, prefix, suffix);
+    /// <summary>
+    /// Get topic name from event handler.
+    /// </summary>
+    /// <param name="handler">Subscription event handler.</param>
+    /// <param name="topic">Subscription topic.</param>
+    /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+    /// <param name="suffix">Dot delimited suffix, which can include version.</param>
+    /// <returns>Fully qualified topic name.</returns>
+    protected string GetTopicName(
+        IIntegrationEventHandler handler,
+        string? topic,
+        string? prefix,
+        string? suffix)
+    {
+        var eventType = handler.GetType().BaseType?.GetGenericArguments().FirstOrDefault();
+        SetTopicFromAttribute(ref topic, ref prefix, ref suffix, eventType);
+        return FormatTopicName(handler.Topic, topic, prefix, suffix);
+    }
 
-        /// <summary>
-        /// Get topic name from event handler.
-        /// </summary>
-        /// <param name="eventType">Integration event type.</param>
-        /// <param name="topic">Subscription topic.</param>
-        /// <param name="prefix">Dot delimited prefix, which can include version.</param>
-        /// <param name="suffix">Dot delimited suffix, which can include version.</param>
-        /// <returns>Fully qualified topic name.</returns>
-        protected string GetTopicName(
-            Type eventType,
-            string? topic,
-            string? prefix,
-            string? suffix) => FormatTopicName(eventType.Name, topic, prefix, suffix);
+    /// <summary>
+    /// Get topic name from event handler.
+    /// </summary>
+    /// <param name="eventType">Integration event type.</param>
+    /// <param name="topic">Subscription topic.</param>
+    /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+    /// <param name="suffix">Dot delimited suffix, which can include version.</param>
+    /// <returns>Fully qualified topic name.</returns>
+    protected string GetTopicName(
+        Type eventType,
+        string? topic,
+        string? prefix,
+        string? suffix)
+    {
+        SetTopicFromAttribute(ref topic, ref prefix, ref suffix, eventType);
+        return FormatTopicName(eventType.Name, topic, prefix, suffix);
+    }
 
-        private string FormatTopicName(
-            string implicitTopic,
-            string? explicitTopic,
-            string? prefix,
-            string? suffix)
-        {
-            var topicName = string.IsNullOrWhiteSpace(explicitTopic) ? implicitTopic : explicitTopic;
-            topicName = string.IsNullOrWhiteSpace(prefix) ? topicName : $"{prefix}.{topicName}";
-            topicName = string.IsNullOrWhiteSpace(suffix) ? topicName : $"{topicName}.{suffix}";
-            return topicName;
-        }
+    private void SetTopicFromAttribute(ref string? topic, ref string? prefix, ref string? suffix, Type? eventType)
+    {
+        var attribute = eventType?.GetCustomAttribute<TopicInfoAttribute>();
+        if (attribute is null ||
+            topic is not null ||
+            prefix is not null ||
+            suffix is not null) return;
+        topic = attribute.Topic;
+        prefix = attribute.Prefix;
+        suffix = attribute.Suffix;
+    }
+
+    private string FormatTopicName(
+        string implicitTopic,
+        string? explicitTopic,
+        string? prefix,
+        string? suffix)
+    {
+        var topicName = string.IsNullOrWhiteSpace(explicitTopic) ? implicitTopic : explicitTopic;
+        topicName = string.IsNullOrWhiteSpace(prefix) ? topicName : $"{prefix}.{topicName}";
+        topicName = string.IsNullOrWhiteSpace(suffix) ? topicName : $"{topicName}.{suffix}";
+        return topicName;
     }
 }

--- a/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
+++ b/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Description>An event bus abstraction layer.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>eda-logo.jpeg</PackageIcon>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>event-bus event-driven event-driven-architecture</PackageTags>
-    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions/releases/tag/v1.3.1</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions/releases/tag/v1.3.2</PackageReleaseNotes>
     <PackageId>EventDriven.EventBus.Abstractions</PackageId>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/EventDriven.EventBus.Abstractions/TopicInfoAttribute.cs
+++ b/src/EventDriven.EventBus.Abstractions/TopicInfoAttribute.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace EventDriven.EventBus.Abstractions;
+
+/// <summary>
+/// Attribute for storing topic info for events.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+public class TopicInfoAttribute : Attribute
+{
+    /// <summary>
+    /// Ctor for TopicInfoAttribute.
+    /// </summary>
+    /// <param name="topic">Event topic.</param>
+    /// <param name="prefix">Dot delimited prefix, which can include version.</param>
+    /// <param name="suffix">Dot delimited suffix, which can include version.</param>
+    public TopicInfoAttribute(string? topic = null, string? prefix = null, string? suffix = null)
+    {
+        Topic = topic;
+        Prefix = prefix;
+        Suffix = suffix;
+    }
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string? Topic { get; }
+
+    /// <summary>
+    /// Dot delimited prefix, which can include version.
+    /// </summary>
+    public string? Prefix { get; }
+
+    /// <summary>
+    /// Dot delimited suffix, which can include version.
+    /// </summary>
+    public string? Suffix { get; }
+}

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventBusWithAttributeTests.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventBusWithAttributeTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventDriven.EventBus.Abstractions.Tests;
+
+public class EventBusWithAttributeTests
+{
+    private class FakeEventBus : EventBus
+    {
+        public string? TopicName { get; private set; }
+
+        public override Task PublishAsync<TIntegrationEvent>
+            (TIntegrationEvent @event, string? topic = null, string? prefix = null, string? suffix = null)
+        {
+            TopicName = GetTopicName(@event.GetType(), topic, prefix, suffix);
+            return Task.CompletedTask;
+        }
+    }
+
+    private const string Topic = "my-topic";
+    private const string Prefix = "my-prefix";
+    private const string Suffix = "my-suffix";
+
+    private const string TopicParam = "my-topic-param";
+    private const string PrefixParam = "my-prefix-param";
+    private const string SuffixParam = "my-suffix-param";
+
+    [TopicInfo(Topic)]
+    private record FakeIntegrationEventWithTopic : IntegrationEvent;
+
+    [TopicInfo]
+    private record FakeIntegrationEventNoTopic : IntegrationEvent;
+
+    [TopicInfo(Topic, Prefix)]
+    private record FakeIntegrationEventWithTopicPrefix : IntegrationEvent;
+
+    [TopicInfo(Topic, null, Suffix)]
+    private record FakeIntegrationEventWithTopicSuffix : IntegrationEvent;
+
+    [TopicInfo(Topic, Prefix, Suffix)]
+    private record FakeIntegrationEventWithTopicPrefixSuffix : IntegrationEvent;
+
+    private class FakeHandlerWithTopic : IntegrationEventHandler<FakeIntegrationEventWithTopic>
+    {
+        public override Task HandleAsync(FakeIntegrationEventWithTopic @event) => throw new NotImplementedException();
+    }
+
+    private class FakeHandlerWithNoTopic : IntegrationEventHandler<FakeIntegrationEventNoTopic>
+    {
+        public override Task HandleAsync(FakeIntegrationEventNoTopic @event) => throw new NotImplementedException();
+    }
+
+    private class FakeHandlerWithTopicPrefix : IntegrationEventHandler<FakeIntegrationEventWithTopicPrefix>
+    {
+        public override Task HandleAsync(FakeIntegrationEventWithTopicPrefix @event) => throw new NotImplementedException();
+    }
+
+    private class FakeHandlerWithTopicSuffix : IntegrationEventHandler<FakeIntegrationEventWithTopicSuffix>
+    {
+        public override Task HandleAsync(FakeIntegrationEventWithTopicSuffix @event) => throw new NotImplementedException();
+    }
+
+    private class FakeHandlerWithTopicPrefixSuffix : IntegrationEventHandler<FakeIntegrationEventWithTopicPrefixSuffix>
+    {
+        public override Task HandleAsync(FakeIntegrationEventWithTopicPrefixSuffix @event) => throw new NotImplementedException();
+    }
+
+    [Theory]
+    [InlineData(null, PrefixParam, null, $"{PrefixParam}.FakeIntegrationEventWithTopicPrefixSuffix")]
+    [InlineData(null, null, SuffixParam, $"FakeIntegrationEventWithTopicPrefixSuffix.{SuffixParam}")]
+    [InlineData(null, PrefixParam, SuffixParam, $"{PrefixParam}.FakeIntegrationEventWithTopicPrefixSuffix.{SuffixParam}")]
+    [InlineData(TopicParam, null, null, TopicParam)]
+    [InlineData(TopicParam, PrefixParam, null, $"{PrefixParam}.{TopicParam}")]
+    [InlineData(TopicParam, null, SuffixParam, $"{TopicParam}.{SuffixParam}")]
+    [InlineData(TopicParam, PrefixParam, SuffixParam, $"{PrefixParam}.{TopicParam}.{SuffixParam}")]
+    public void Subscribe_WithArgs_ForHandlerWithTopic_ShouldUseArgsValues(string? topic, string? prefix, string? suffix, string expectedTopicName)
+    {
+        // arrange
+        var busFake = new FakeEventBus();
+        var handler = new FakeHandlerWithTopicPrefixSuffix();
+
+        // act
+        busFake.Subscribe(handler, topic, prefix, suffix);
+
+        // assert
+        Assert.Contains(expectedTopicName, busFake.Topics.Keys);
+    }
+
+    [Theory]
+    [InlineData(IntegrationEventType.NoTopic)]
+    [InlineData(IntegrationEventType.WithTopic)]
+    [InlineData(IntegrationEventType.WithTopicPrefix)]
+    [InlineData(IntegrationEventType.WithTopicSuffix)]
+    [InlineData(IntegrationEventType.WithTopicPrefixSuffix)]
+    public void Subscribe_ForHandlerWithAttribute_ShouldUseAttribute(IntegrationEventType integrationEventType)
+    {
+        // arrange
+        var busFake = new FakeEventBus();
+        var handler = GetHandler(integrationEventType);
+        var topicName = GetTopicName(integrationEventType);
+
+        // act
+        busFake.Subscribe(handler!);
+
+        // assert
+        Assert.Contains(topicName, busFake.Topics.Keys);
+    }
+
+    [Theory]
+    [InlineData(null, PrefixParam, null, $"{PrefixParam}.FakeIntegrationEventWithTopicPrefixSuffix")]
+    [InlineData(null, null, SuffixParam, $"FakeIntegrationEventWithTopicPrefixSuffix.{SuffixParam}")]
+    [InlineData(null, PrefixParam, SuffixParam, $"{PrefixParam}.FakeIntegrationEventWithTopicPrefixSuffix.{SuffixParam}")]
+    [InlineData(TopicParam, null, null, TopicParam)]
+    [InlineData(TopicParam, PrefixParam, null, $"{PrefixParam}.{TopicParam}")]
+    [InlineData(TopicParam, null, SuffixParam, $"{TopicParam}.{SuffixParam}")]
+    [InlineData(TopicParam, PrefixParam, SuffixParam, $"{PrefixParam}.{TopicParam}.{SuffixParam}")]
+    public async Task PublishAsync_WithArgs_ForEventWithAttribute_ShouldUseArgsValues(string? topic, string? prefix, string? suffix, string expectedTopicName)
+    {
+        // arrange
+        var busFake = new FakeEventBus();
+        var @event = new FakeIntegrationEventWithTopicPrefixSuffix();
+        // act
+        await busFake.PublishAsync(@event, topic, prefix, suffix);
+
+        // assert
+        Assert.Equal(expectedTopicName, busFake.TopicName);
+    }
+
+    [Theory]
+    [InlineData(IntegrationEventType.NoTopic)]
+    [InlineData(IntegrationEventType.WithTopic)]
+    [InlineData(IntegrationEventType.WithTopicPrefix)]
+    [InlineData(IntegrationEventType.WithTopicSuffix)]
+    [InlineData(IntegrationEventType.WithTopicPrefixSuffix)]
+    public async Task PublishAsync_WithoutArgs_ForEventWithAttribute_ShouldUseAttribute(IntegrationEventType integrationEventType)
+    {
+        var busFake = new FakeEventBus();
+        var @event = GetEvent(integrationEventType);
+        var topicName = GetTopicName(integrationEventType);
+
+        await busFake.PublishAsync(@event);
+
+        Assert.Equal(topicName, busFake.TopicName);
+    }
+
+    private string? GetTopicName(IntegrationEventType integrationEventType)
+    {
+        return integrationEventType switch
+        {
+            IntegrationEventType.NoTopic => nameof(FakeIntegrationEventNoTopic),
+            IntegrationEventType.WithTopic => Topic,
+            IntegrationEventType.WithTopicPrefix => $"{Prefix}.{Topic}",
+            IntegrationEventType.WithTopicSuffix => $"{Topic}.{Suffix}",
+            IntegrationEventType.WithTopicPrefixSuffix => $"{Prefix}.{Topic}.{Suffix}",
+            _ => null
+        };
+    }
+
+    private IIntegrationEventHandler? GetHandler(IntegrationEventType integrationEventType)
+    {
+        return integrationEventType switch
+        {
+            IntegrationEventType.NoTopic => new FakeHandlerWithNoTopic(),
+            IntegrationEventType.WithTopic => new FakeHandlerWithTopic(),
+            IntegrationEventType.WithTopicPrefix => new FakeHandlerWithTopicPrefix(),
+            IntegrationEventType.WithTopicSuffix => new FakeHandlerWithTopicSuffix(),
+            IntegrationEventType.WithTopicPrefixSuffix => new FakeHandlerWithTopicPrefixSuffix(),
+            _ => null
+        };
+    }
+
+    private IntegrationEvent GetEvent(IntegrationEventType integrationEventType)
+    {
+        return integrationEventType switch
+        {
+            IntegrationEventType.NoTopic => new FakeIntegrationEventNoTopic(),
+            IntegrationEventType.WithTopic => new FakeIntegrationEventWithTopic(),
+            IntegrationEventType.WithTopicPrefix => new FakeIntegrationEventWithTopicPrefix(),
+            IntegrationEventType.WithTopicSuffix => new FakeIntegrationEventWithTopicSuffix(),
+            IntegrationEventType.WithTopicPrefixSuffix => new FakeIntegrationEventWithTopicPrefixSuffix(),
+            _ => new FakeIntegrationEventNoTopic()
+        };
+    }
+    
+    public enum IntegrationEventType
+    {
+        NoTopic,
+        WithTopic,
+        WithTopicPrefix,
+        WithTopicSuffix,
+        WithTopicPrefixSuffix
+    }
+}

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventDriven.EventBus.Abstractions.Tests.csproj
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventDriven.EventBus.Abstractions.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/EventDriven.EventBus.Abstractions.Tests/TopicInfoAttributeTests.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/TopicInfoAttributeTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace EventDriven.EventBus.Abstractions.Tests;
+
+public class TopicInfoAttributeTests
+{
+    [Theory]
+    [InlineData("", "", "")]
+    [InlineData(null, null, null)]
+    [InlineData(" ", " ", " ")]
+    [InlineData("some-topic", "some-prefix", "some-suffix")]
+    [InlineData("some-topic", "", "some-suffix")]
+    [InlineData("some-topic", "some-prefix", null)]
+    public void CreateInstance_TopicInfoAttribute_ShouldBeCreate(string name, string prefix, string suffix)
+    {
+        // act
+        var attribute = new TopicInfoAttribute(name, prefix, suffix);
+
+        // assert
+        Assert.IsType<TopicInfoAttribute>(attribute);
+        Assert.Equal(name, attribute.Topic);
+        Assert.Equal(prefix, attribute.Prefix);
+        Assert.Equal(suffix, attribute.Suffix);
+    }
+}


### PR DESCRIPTION
Add `TopicInfoAttribute` to decorate integration events, so that Topic, Prefix and Suffix can be added to the attribute instead of passed explicitly to `PublishAsync` and `Subscribe` methods.

Closes #5.
