### PR TITLE
Add retry support

### DIFF
--- a/src/EventDriven.EventBus.Abstractions/EventCacheOptions.cs
+++ b/src/EventDriven.EventBus.Abstractions/EventCacheOptions.cs
@@ -26,4 +26,9 @@ public class EventCacheOptions
     /// Event cache cleanup interval. Defaults to 5 minutes.
     /// </summary>
     public TimeSpan EventCacheCleanupInterval { get; set; } = TimeSpan.FromMinutes(5);
+    
+    /// <summary>
+    /// Event errors cache cleanup interval. Defaults to 15 minutes.
+    /// </summary>
+    public TimeSpan EventErrorsCacheCleanupInterval { get; set; } = TimeSpan.FromMinutes(15);
 }

--- a/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
+++ b/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.2</Version>
+    <Version>1.4.0</Version>
     <Description>An event bus abstraction layer.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>eda-logo.jpeg</PackageIcon>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>event-bus event-driven event-driven-architecture</PackageTags>
-    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions/releases/tag/v1.3.2</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Abstractions/releases/tag/v1.4.0</PackageReleaseNotes>
     <PackageId>EventDriven.EventBus.Abstractions</PackageId>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/EventDriven.EventBus.Abstractions/EventHandling.cs
+++ b/src/EventDriven.EventBus.Abstractions/EventHandling.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace EventDriven.EventBus.Abstractions;
 
@@ -26,6 +27,11 @@ public class EventHandling
     /// Timespan during which event is considered to be handled.
     /// </summary>
     public TimeSpan EventHandledTimeout { get; set; }
+
+    /// <summary>
+    /// Handlers for the event.
+    /// </summary>
+    public Dictionary<string, HandlerInfo> Handlers { get; set; } = new();
 }
 
 /// <summary>
@@ -55,4 +61,9 @@ public class EventHandling<TIntegrationEvent>
     /// Timespan during which event is considered to be handled.
     /// </summary>
     public TimeSpan EventHandledTimeout { get; set; }
+    
+    /// <summary>
+    /// Handlers for the event.
+    /// </summary>
+    public Dictionary<string, HandlerInfo> Handlers { get; set; } = new();
 }

--- a/src/EventDriven.EventBus.Abstractions/HandlerInfo.cs
+++ b/src/EventDriven.EventBus.Abstractions/HandlerInfo.cs
@@ -1,0 +1,17 @@
+namespace EventDriven.EventBus.Abstractions;
+
+/// <summary>
+/// Handler information.
+/// </summary>
+public class HandlerInfo
+{
+    /// <summary>
+    /// True if handler is in an error state.
+    /// </summary>
+    public bool HasError { get; set; }
+
+    /// <summary>
+    /// Error message (if anyy)
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/src/EventDriven.EventBus.Abstractions/IEventCache.cs
+++ b/src/EventDriven.EventBus.Abstractions/IEventCache.cs
@@ -8,23 +8,25 @@ namespace EventDriven.EventBus.Abstractions;
 public interface IEventCache
 {
     /// <summary>
-    /// Attempts to add the integration event to the event cache.
+    /// Check if integration event has been handled.
     /// </summary>
     /// <param name="event">The integration event</param>
-    /// <returns>
-    /// True if the event was added to the event cache.
-    /// False if the event is in the cache and not expired or it cannot be removed. 
-    /// </returns>
-    bool TryAdd(IntegrationEvent @event);
-    
-    /// <summary>
-    /// Attempts to add the integration event to the event cache.
-    /// </summary>
-    /// <param name="event">The integration event</param>
+    /// <param name="handlerTypeName">Handler type name</param>
     /// <returns>
     /// Task that will complete when the operation has completed.
-    /// Task contains true if the event was added to the event cache,
-    /// false if the event is in the cache and not expired or it cannot be removed.
+    /// Task contains true if the event is in the event cache, not expired and not in an error state;
+    /// false if the event is not in the cache, is expired or is in an error state.
     /// </returns>
-    Task<bool> TryAddAsync(IntegrationEvent @event);
+    Task<bool> HasBeenHandledAsync(IntegrationEvent @event, string handlerTypeName);
+
+    /// <summary>
+    /// Add integration event to the event cache, or update event with error state.
+    /// </summary>
+    /// <param name="event">The integration event</param>
+    /// <param name="handlerTypeName">Handler type name</param>
+    /// <param name="errorMessage">Error message</param>
+    /// <returns>
+    /// Task that will complete when the operation has completed.
+    /// </returns>
+    Task AddEventAsync(IntegrationEvent @event, string? handlerTypeName = null, string? errorMessage = null);
 }

--- a/src/EventDriven.EventBus.Abstractions/IEventHandlingRepository.cs
+++ b/src/EventDriven.EventBus.Abstractions/IEventHandlingRepository.cs
@@ -49,12 +49,13 @@ public interface IEventHandlingRepository<TIntegrationEvent>
     /// Get expired integration events.
     /// </summary>
     /// <param name="appName">Optional app name.</param>
+    /// <param name="excludeErrors">True to exclude events with errors. Defaults to true.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
     /// <returns>
     /// A <see cref="Task" /> that will complete when the operation has completed.
     /// Task contains an IEnumerable of EventWrapper of TIntegrationEvent.
     /// </returns>
     Task<IEnumerable<EventWrapper<TIntegrationEvent>>> GetExpiredEventsAsync(
-        string? appName = null,
+        string? appName = null, bool excludeErrors = true,
         CancellationToken cancellationToken = default);
 }

--- a/src/EventDriven.EventBus.Abstractions/InMemoryEventCache.cs
+++ b/src/EventDriven.EventBus.Abstractions/InMemoryEventCache.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,12 +22,17 @@ public class InMemoryEventCache : IEventCache
     /// <summary>
     /// Thread-safe event cache.
     /// </summary>
-    protected ConcurrentDictionary<string, EventHandling> Cache { get; } = new();
+    protected Dictionary<string, EventHandling> Cache { get; } = new();
 
     /// <summary>
     /// Cleanup timer.
     /// </summary>
     protected Timer? CleanupTimer { get; }
+
+    /// <summary>
+    /// Errors cleanup timer.
+    /// </summary>
+    protected Timer? ErrorsCleanupTimer { get; }
 
     /// <summary>
     /// Cancellation token.
@@ -45,13 +50,18 @@ public class InMemoryEventCache : IEventCache
     {
         EventCacheOptions = eventCacheOptions;
         CancellationToken = cancellationToken;
-        async void TimerCallback(object? state) => await CleanupEventCacheAsync();
         if (EventCacheOptions.EnableEventCacheCleanup)
+        {
             CleanupTimer = new Timer(TimerCallback, null, TimeSpan.Zero, EventCacheOptions.EventCacheCleanupInterval);
+            ErrorsCleanupTimer = new Timer(ErrorsTimerCallback, null, TimeSpan.Zero, EventCacheOptions.EventErrorsCacheCleanupInterval);
+        }
+        return;
+        async void TimerCallback(object? state) => await CleanupEventCacheAsync();
+        async void ErrorsTimerCallback(object? state) => await CleanupEventCacheErrorsAsync();
     }
 
     /// <summary>
-    /// Cleans up event cache.
+    /// Clean up event cache.
     /// </summary>
     /// <returns>Task that will complete when the operation has completed.</returns>
     protected virtual async Task CleanupEventCacheAsync()
@@ -65,33 +75,69 @@ public class InMemoryEventCache : IEventCache
                 return;
             }
 
-            // Remove expired events
+            // Remove expired events without errors
             var expired = Cache
                 .Where(kvp =>
-                    kvp.Value.EventHandledTimeout < DateTime.UtcNow - kvp.Value.EventHandledTime);
+                    DateTime.UtcNow > kvp.Value.EventHandledTime + kvp.Value.EventHandledTimeout
+                    && !kvp.Value.Handlers.Any(h => h.Value.HasError));
             foreach (var keyValuePair in expired)
-                Cache.TryRemove(keyValuePair);
+                Cache.Remove(keyValuePair.Key);
+        }
+    }
+
+    /// <summary>
+    /// Clean up event cache errors.
+    /// </summary>
+    /// <returns>Task that will complete when the operation has completed.</returns>
+    protected virtual async Task CleanupEventCacheErrorsAsync()
+    {
+        using (await _syncRoot.LockAsync(CancellationToken))
+        {
+            // End timer and exit if cache cleanup disabled or cancellation pending
+            if (!EventCacheOptions.EnableEventCacheCleanup || CancellationToken.IsCancellationRequested)
+            {
+                if (ErrorsCleanupTimer != null) await ErrorsCleanupTimer.DisposeAsync();
+                return;
+            }
+
+            // Remove expired events with errors
+            var expiredWithErrors = Cache
+                .Where(kvp =>
+                    DateTime.UtcNow > kvp.Value.EventHandledTime + kvp.Value.EventHandledTimeout
+                    && kvp.Value.Handlers.Any(h => h.Value.HasError));
+            foreach (var keyValuePair in expiredWithErrors)
+                Cache.Remove(keyValuePair.Key);
         }
     }
 
     /// <inheritdoc />
-    public virtual bool TryAdd(IntegrationEvent @event)
+    public Task<bool> HasBeenHandledAsync(IntegrationEvent @event, string handlerTypeName)
     {
-        // Return true if not enabled
-        if (!EventCacheOptions.EnableEventCache) return true;
+        // Return false if not enabled
+        if (!EventCacheOptions.EnableEventCache) return Task.FromResult(false);
         
-        // Return false if event exists and is not expired
-        bool expired = false;
-        if (Cache.TryGetValue(@event.Id, out var existing))
-            expired = existing.EventHandledTimeout < DateTime.UtcNow - existing.EventHandledTime;
-        if (existing != null && !expired) return false;
+        // Return true if event exists, is not expired, and handler has no error
+        var exists = Cache.TryGetValue(@event.Id, out var handling);
+        var expired = handling != null &&
+                      DateTime.UtcNow > handling.EventHandledTime + handling.EventHandledTimeout;
+        var hasError = handling != null &&
+                       handling.Handlers.ContainsKey(handlerTypeName) &&
+                       handling.Handlers[handlerTypeName].HasError;
+        var hasBeenHandled = exists && !(expired || hasError);
+        return Task.FromResult(hasBeenHandled);
+    }
+
+    /// <inheritdoc />
+    public Task AddEventAsync(IntegrationEvent @event,
+        string? handlerTypeName = null, string? errorMessage = null)
+    {
+        // Return if cache not enabled
+        if (!EventCacheOptions.EnableEventCache) return Task.CompletedTask;
         
-        // Remove existing; return false if unable to remove
-        if (existing != null
-            && !Cache.TryRemove(@event.Id, out existing))
-            return false;
-            
-        // Add event handling
+        // Remove existing event
+        Cache.Remove(@event.Id);
+        
+        // Add new event
         var handling = new EventHandling
         {
             EventId = @event.Id,
@@ -99,10 +145,16 @@ public class InMemoryEventCache : IEventCache
             EventHandledTime = DateTime.UtcNow,
             EventHandledTimeout = EventCacheOptions.EventCacheTimeout
         };
-        return Cache.TryAdd(@event.Id, handling);
+        if (!string.IsNullOrWhiteSpace(handlerTypeName))
+        {
+            handling.Handlers.Add(handlerTypeName, new HandlerInfo
+            {
+                HasError = !string.IsNullOrWhiteSpace(errorMessage),
+                ErrorMessage = !string.IsNullOrWhiteSpace(errorMessage)
+                    ? errorMessage : null
+            });
+        }
+        Cache.Add(@event.Id, handling);
+        return Task.CompletedTask;
     }
-
-    /// <inheritdoc />
-    public Task<bool> TryAddAsync(IntegrationEvent? @event) =>
-        Task.FromResult(TryAdd(@event!));
 }

--- a/src/EventDriven.EventBus.Abstractions/IntegrationEvent.cs
+++ b/src/EventDriven.EventBus.Abstractions/IntegrationEvent.cs
@@ -3,7 +3,7 @@
 namespace EventDriven.EventBus.Abstractions
 {
     /// <inheritdoc cref="IIntegrationEvent" />
-    public abstract record IntegrationEvent : IIntegrationEvent
+    public record IntegrationEvent : IIntegrationEvent
     {
         ///<inheritdoc/>
         public string Id { get; set; } = Guid.NewGuid().ToString();

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventBusTests.cs
@@ -4,170 +4,182 @@ using System.Threading.Tasks;
 using EventDriven.EventBus.Abstractions.Tests.Fakes;
 using Xunit;
 
-namespace EventDriven.EventBus.Abstractions.Tests
+namespace EventDriven.EventBus.Abstractions.Tests;
+
+public class EventBusTests
 {
-    public class EventBusTests
+    [Theory]
+    [InlineData(TopicType.Implicit, null, null)]
+    [InlineData(TopicType.Implicit, "v1", null)]
+    [InlineData(TopicType.Explicit, null, null)]
+    [InlineData(TopicType.Explicit, "v1", null)]
+    [InlineData(TopicType.Explicit, null, "suffix")]
+    [InlineData(TopicType.Explicit, "v1", "suffix")]
+    public async Task EventBus_Should_Invoke_Event_Handlers(TopicType topicType, string prefix, string suffix)
     {
-        [Theory]
-        [InlineData(TopicType.Implicit, null, null)]
-        [InlineData(TopicType.Implicit, "v1", null)]
-        [InlineData(TopicType.Explicit, null, null)]
-        [InlineData(TopicType.Explicit, "v1", null)]
-        [InlineData(TopicType.Explicit, null, "suffix")]
-        [InlineData(TopicType.Explicit, "v1", "suffix")]
-        public async Task EventBus_Should_Invoke_Event_Handlers(TopicType topicType, string prefix, string suffix)
-        {
-            // Topic name
-            var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
+        // Topic name
+        var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
             
-            // Create handlers
-            var state = new FakeState { Data = "A" };
-            var fakeHandler1 = new FakeEventHandler1(state);
-            var fakeHandler2 = new FakeEventHandler2(state);
+        // Create handlers
+        var state = new FakeState { Data = "A" };
+        var fakeHandler1 = new FakeEventHandler1(state);
+        var fakeHandler2 = new FakeEventHandler2(state);
 
-            // Create message broker
-            var messageBroker = new FakeMessageBroker();
-            messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
-            messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
+        // Create message broker
+        var messageBroker = new FakeMessageBroker();
+        messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
+        messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
-            // Create event bus
-            var eventBus = new FakeEventBus(messageBroker);
-            eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
-            eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
+        // Create event bus
+        var eventBus = new FakeEventBus(messageBroker, false);
+        eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
+        eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
 
-            // Publish to service bus
-            var @event = new FakeIntegrationEvent("B");
-            await eventBus.PublishAsync(@event, topicName, prefix, suffix);
+        // Publish to service bus
+        var @event = new FakeIntegrationEvent("B");
+        await eventBus.PublishAsync(@event, topicName, prefix, suffix);
 
-            // Assert
-            Assert.Equal(@event.CreationDate, state.Date);
-            Assert.Equal("B", state.Data);
-        }
-        
-        [Theory]
-        [InlineData(TopicType.Implicit, null, null)]
-        [InlineData(TopicType.Implicit, "v1", null)]
-        [InlineData(TopicType.Explicit, null, null)]
-        [InlineData(TopicType.Explicit, "v1", null)]
-        [InlineData(TopicType.Explicit, null, "suffix")]
-        [InlineData(TopicType.Explicit, "v1", "suffix")]
-        public void EventBus_Should_Remove_Event_Handlers(TopicType topicType, string prefix, string suffix)
-        {
-            // Topic name
-            var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
-            
-            // Create handlers
-            var state = new FakeState { Data = "A" };
-            var fakeHandler1 = new FakeEventHandler1(state);
-            var fakeHandler2 = new FakeEventHandler2(state);
-
-            // Create message broker
-            var messageBroker = new FakeMessageBroker();
-            messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
-            messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
-
-            // Create event bus
-            var eventBus = new FakeEventBus(messageBroker);
-            eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
-            eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
-
-            // Remove handler
-            eventBus.UnSubscribe(fakeHandler1, topicName, prefix, suffix);
-
-            // Assert
-            Assert.Single(eventBus.Topics);
-            Assert.Single(eventBus.Topics.First().Value);
-            
-            // Remove handler
-            eventBus.UnSubscribe(fakeHandler2, topicName, prefix, suffix);
-
-            // Assert
-            Assert.Empty(eventBus.Topics);
-        }
-        
-        [Theory]
-        [InlineData(false, false, 2)]
-        [InlineData(true, false, 2)]
-        [InlineData(true, true, 2)]
-        public async Task EventBus_With_Cache_Should_Invoke_Event_Handlers(bool enableCache, bool expire, int iterations)
-        {
-            // Create handler
-            var initial = 1;
-            var state = new FakeState { Value = initial };
-            var fakeHandler3 = new FakeEventHandler3(state);
-
-            // Create message broker
-            const string prefix = "v1";
-            var options = new EventCacheOptions
-            {
-                EnableEventCache = enableCache,
-                EventCacheTimeout = expire ? TimeSpan.FromMilliseconds(200) : TimeSpan.FromSeconds(60),
-                EnableEventCacheCleanup = false
-            };
-            var eventCache = new InMemoryEventCache(options);
-            var messageBroker = new FakeCachingMessageBroker(eventCache);
-            messageBroker.Subscribe(fakeHandler3, null, prefix);
-
-            // Create event bus
-            var eventBus = new FakeRepeatingEventBus(messageBroker, options, iterations, expire);
-            messageBroker.EventBus = eventBus;
-            eventBus.Subscribe(fakeHandler3, null, prefix);
-
-            // Publish to service bus
-            var @event = new FakeIntegrationEvent(string.Empty);
-            await eventBus.PublishAsync(@event, null, prefix);
-
-            // Assert
-            var expected = enableCache ? initial + 1 : initial + iterations;
-            if (enableCache && expire) expected = initial + iterations;
-            Assert.Equal(expected, state.Value);
-        }
-        
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task EventBus_With_Cache_Should_Clean_Up_Event_Handlers(bool enableCacheCleanup)
-        {
-            // Create handler
-            var initial = 1;
-            var state = new FakeState { Value = initial };
-            var fakeHandler1 = new FakeEventHandler1(state);
-
-            // Create message broker
-            const string prefix = "v1";
-            var options = new EventCacheOptions
-            {
-                EnableEventCache = true,
-                EventCacheTimeout = TimeSpan.FromMilliseconds(20),
-                EnableEventCacheCleanup = enableCacheCleanup,
-                EventCacheCleanupInterval = TimeSpan.FromMilliseconds(80)
-            };
-            var eventCache = new FakeInMemoryEventCache(options);
-            var messageBroker = new FakeCachingMessageBroker(eventCache);
-            messageBroker.Subscribe(fakeHandler1, null, prefix);
-
-            // Create event bus
-            var eventBus = new FakeEventBus(messageBroker);
-            messageBroker.EventBus = eventBus;
-            eventBus.Subscribe(fakeHandler1, null, prefix);
-
-            // Publish to service bus
-            var event1 = new FakeIntegrationEvent(string.Empty);
-            var event2 = new FakeIntegrationEvent(string.Empty);
-            await eventBus.PublishAsync(event1, null, prefix);
-            await eventBus.PublishAsync(event2, null, prefix);
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
-
-            // Assert
-            var expected = enableCacheCleanup ? 0 : 2;
-            var actual = eventCache.GetCacheCount();
-            Assert.Equal(expected, actual);
-        }
+        // Assert
+        Assert.Equal(@event.CreationDate, state.Date);
+        Assert.Equal("B", state.Data);
     }
-
-    public enum TopicType
+        
+    [Theory]
+    [InlineData(TopicType.Implicit, null, null)]
+    [InlineData(TopicType.Implicit, "v1", null)]
+    [InlineData(TopicType.Explicit, null, null)]
+    [InlineData(TopicType.Explicit, "v1", null)]
+    [InlineData(TopicType.Explicit, null, "suffix")]
+    [InlineData(TopicType.Explicit, "v1", "suffix")]
+    public void EventBus_Should_Remove_Event_Handlers(TopicType topicType, string prefix, string suffix)
     {
-        Implicit,
-        Explicit
+        // Topic name
+        var topicName = topicType == TopicType.Explicit ? "my-topic" : null;
+            
+        // Create handlers
+        var state = new FakeState { Data = "A" };
+        var fakeHandler1 = new FakeEventHandler1(state);
+        var fakeHandler2 = new FakeEventHandler2(state);
+
+        // Create message broker
+        var messageBroker = new FakeMessageBroker();
+        messageBroker.Subscribe(fakeHandler1, topicName, prefix, suffix);
+        messageBroker.Subscribe(fakeHandler2, topicName, prefix, suffix);
+
+        // Create event bus
+        var eventBus = new FakeEventBus(messageBroker, false);
+        eventBus.Subscribe(fakeHandler1, topicName, prefix, suffix);
+        eventBus.Subscribe(fakeHandler2, topicName, prefix, suffix);
+
+        // Remove handler
+        eventBus.UnSubscribe(fakeHandler1, topicName, prefix, suffix);
+
+        // Assert
+        Assert.Single(eventBus.Topics);
+        Assert.Single(eventBus.Topics.First().Value);
+            
+        // Remove handler
+        eventBus.UnSubscribe(fakeHandler2, topicName, prefix, suffix);
+
+        // Assert
+        Assert.Empty(eventBus.Topics);
     }
+        
+    [Theory]
+    [InlineData(false, false, false, 2)]
+    [InlineData(true, false, false, 2)]
+    [InlineData(true, false, true, 2)]
+    [InlineData(true, true, false, 2)]
+    public async Task EventBus_With_Cache_Should_Invoke_Event_Handlers(bool enableCache, bool expire, 
+        bool hasError, int iterations)
+    {
+        // Create handler
+        var initial = 1;
+        var state = new FakeState { Value = initial };
+        var fakeHandler3 = new FakeEventHandler3(state);
+
+        // Create message broker
+        const string prefix = "v1";
+        var options = new EventCacheOptions
+        {
+            EnableEventCache = enableCache,
+            EventCacheTimeout = expire ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromSeconds(60),
+            EnableEventCacheCleanup = false
+        };
+        var eventCache = new InMemoryEventCache(options);
+        var messageBroker = new FakeCachingMessageBroker(eventCache);
+        messageBroker.Subscribe(fakeHandler3, null, prefix);
+
+        // Create event bus
+        var eventBus = new FakeRepeatingEventBus(messageBroker, options, iterations, expire, hasError);
+        messageBroker.EventBus = eventBus;
+        eventBus.Subscribe(fakeHandler3, null, prefix);
+
+        // Publish to service bus
+        var @event = new FakeIntegrationEvent(string.Empty);
+        await eventBus.PublishAsync(@event, null, prefix);
+
+        // Assert
+        var expected = enableCache ? initial + 1 : initial + iterations;
+        if (enableCache && expire) expected = initial + iterations;
+        if (hasError) expected = initial;
+        Assert.Equal(expected, state.Value);
+    }
+        
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, true, true)]
+    public async Task EventBus_With_Cache_Should_Clean_Up_Events(bool enableCacheCleanup,
+        bool hasError, bool cleanupErrors)
+    {
+        // Create handler
+        var initial = 1;
+        var state = new FakeState { Value = initial };
+        var fakeHandler1 = new FakeEventHandler1(state);
+        var cleanupInterval = TimeSpan.FromMilliseconds(100);
+
+        // Create message broker
+        const string prefix = "v1";
+        var options = new EventCacheOptions
+        {
+            EnableEventCache = true,
+            EventCacheTimeout = TimeSpan.FromMilliseconds(20),
+            EnableEventCacheCleanup = enableCacheCleanup,
+        };
+        if (cleanupErrors)
+            options.EventErrorsCacheCleanupInterval = cleanupInterval;
+        else
+            options.EventCacheCleanupInterval = cleanupInterval;
+
+        var eventCache = new FakeInMemoryEventCache(options);
+        var messageBroker = new FakeCachingMessageBroker(eventCache);
+        messageBroker.Subscribe(fakeHandler1, null, prefix);
+
+        // Create event bus
+        var eventBus = new FakeEventBus(messageBroker, hasError);
+        messageBroker.EventBus = eventBus;
+        eventBus.Subscribe(fakeHandler1, null, prefix);
+
+        // Publish to service bus
+        var event1 = new FakeIntegrationEvent(string.Empty);
+        var event2 = new FakeIntegrationEvent(string.Empty);
+        await eventBus.PublishAsync(event1, null, prefix);
+        await eventBus.PublishAsync(event2, null, prefix);
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        // Assert
+        var expected = enableCacheCleanup ? 0 : 2;
+        if (hasError) expected = 2;
+        if (cleanupErrors) expected = 0;
+        var actual = eventCache.GetCacheCount();
+        Assert.Equal(expected, actual);
+    }
+}
+
+public enum TopicType
+{
+    Implicit,
+    Explicit
 }

--- a/test/EventDriven.EventBus.Abstractions.Tests/EventDriven.EventBus.Abstractions.Tests.csproj
+++ b/test/EventDriven.EventBus.Abstractions.Tests/EventDriven.EventBus.Abstractions.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeEventBus.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeEventBus.cs
@@ -4,10 +4,12 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
 {
     public class FakeEventBus : EventBus
     {
+        protected readonly bool HasError;
         protected FakeMessageBroker MessageBroker { get; }
 
-        public FakeEventBus(FakeMessageBroker messageBroker)
+        public FakeEventBus(FakeMessageBroker messageBroker, bool hasError)
         {
+            HasError = hasError;
             MessageBroker = messageBroker;
         }
 
@@ -18,7 +20,7 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
             string? suffix = null)
         {
             var topicName = GetTopicName(@event.GetType(), topic, prefix, suffix);
-            await MessageBroker.PublishEventAsync(@event, topicName);
+            await MessageBroker.PublishEventAsync(@event, topicName, HasError);
         }
     }
 }

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeInMemoryEventCache.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeInMemoryEventCache.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace EventDriven.EventBus.Abstractions.Tests.Fakes;
 
 public class FakeInMemoryEventCache : InMemoryEventCache
@@ -9,24 +7,4 @@ public class FakeInMemoryEventCache : InMemoryEventCache
     }
 
     public int GetCacheCount() => Cache.Count;
-
-    public override bool TryAdd(IntegrationEvent @event)
-    {
-        // Return true if not enabled
-        if (!EventCacheOptions.EnableEventCache) return true;
-        
-        // Return false if event exists
-        if (Cache.TryGetValue(@event.Id, out _))
-            return false;
-        
-        // Add event handling
-        var handling = new EventHandling
-        {
-            EventId = @event.Id,
-            IntegrationEvent = @event,
-            EventHandledTime = DateTime.UtcNow,
-            EventHandledTimeout = EventCacheOptions.EventCacheTimeout
-        };
-        return Cache.TryAdd(@event.Id, handling);
-    }
 }

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeMessageBroker.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeMessageBroker.cs
@@ -17,25 +17,18 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
             topicName = string.IsNullOrWhiteSpace(prefix) ? topicName : $"{prefix}.{topicName}";
             topicName = string.IsNullOrWhiteSpace(suffix) ? topicName : $"{topicName}.{suffix}";
             if (Topics.TryGetValue(topicName, out var handlers))
-            {
                 handlers.Add(handler);
-            }
             else
-            {
                 Topics.Add(topicName, new List<IIntegrationEventHandler> { handler });
-            }
         }
 
         public virtual Task PublishEventAsync<TIntegrationEvent>(
             TIntegrationEvent @event,
-            string topic)
+            string topic, bool hasError = false)
             where TIntegrationEvent : IntegrationEvent
         {
             var handlers = Topics[topic];
-            foreach (var handler in handlers)
-            {
-                handler.HandleAsync(@event);
-            }
+            foreach (var handler in handlers) handler.HandleAsync(@event);
             return Task.CompletedTask;
         }
     }

--- a/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeRepeatingEventBus.cs
+++ b/test/EventDriven.EventBus.Abstractions.Tests/Fakes/FakeRepeatingEventBus.cs
@@ -9,8 +9,8 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
         private readonly bool _expire;
 
         public FakeRepeatingEventBus(FakeMessageBroker messageBroker,
-            EventCacheOptions eventBusOptions, int iterations, bool expire) :
-            base(messageBroker)
+            EventCacheOptions eventBusOptions, int iterations, bool expire, bool hasError) :
+            base(messageBroker, hasError)
         {
             _eventBusOptions = eventBusOptions;
             _iterations = iterations;
@@ -26,7 +26,7 @@ namespace EventDriven.EventBus.Abstractions.Tests.Fakes
             var topicName = GetTopicName(@event.GetType(), topic, prefix, suffix);
             for (int i = 0; i < _iterations; i++)
             {
-                await MessageBroker.PublishEventAsync(@event, topicName);
+                await MessageBroker.PublishEventAsync(@event, topicName, HasError);
                 if (_expire) await Task.Delay(_eventBusOptions.EventCacheTimeout * 1.5);
             }
         }


### PR DESCRIPTION
- Add Handlers property with HandlerInfo to EventHandling
- Refactor IEventCache, InMemoryEventCache to support retries when errors occur (breaking changes)
- Add excludeErrors errors parameter to IEventHandlingRepository.GetExpiredEventsAsync
- Make IntegrationEvent non-abstract to fix serialization error
- Set version to 1.4.0