### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
+++ b/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
+++ b/src/EventDriven.EventBus.Abstractions/EventDriven.EventBus.Abstractions.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/EventDriven.EventBus.Abstractions/InMemoryEventCache.cs
+++ b/src/EventDriven.EventBus.Abstractions/InMemoryEventCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace EventDriven.EventBus.Abstractions;
 
@@ -12,7 +12,7 @@ namespace EventDriven.EventBus.Abstractions;
 /// </summary>
 public class InMemoryEventCache : IEventCache
 {
-    private readonly AsyncLock _syncRoot = new();
+    private readonly AsyncNonKeyedLocker _syncRoot = new();
     
     /// <summary>
     /// Event cache options.


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144